### PR TITLE
Add load status, member and view c/ upon create

### DIFF
--- a/lib/pages/create_community_page/create_community.dart
+++ b/lib/pages/create_community_page/create_community.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:linear/util/apis.dart';
+import 'package:linear/pages/community_page/community_page.dart';
 
 class CreateCommunityWidget extends StatefulWidget {
   CreateCommunityWidget({super.key, required this.token});
@@ -17,6 +18,7 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
 
     successfulMessage.then((response) {
       if (response['status'] == true) {
+        joinAndLeave(userInput.text, widget.token);
         showDialog(
             context: context,
             builder: (context) {
@@ -26,9 +28,16 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
                 actions: [
                   TextButton(
                       onPressed: () {
-                        Navigator.pop(context);
-                        //add routintg to community page
-                      },
+                       Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => CommunityPage(
+                          communityName: userInput.text,
+                          token: widget.token,
+                        ),
+                      ),
+                    );
+                  },
                       child: const Text("Ok"))
                 ],
               );
@@ -56,12 +65,6 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
   @override
   Widget build(BuildContext context) {
     return Column(children: [
-      const Center(
-        child: Text(
-          "Create a Community:",
-          style: TextStyle(fontSize: 24),
-        ),
-      ),
       Container(
         margin: const EdgeInsets.all(10),
         child: TextFormField(

--- a/lib/pages/create_community_page/create_community_page.dart
+++ b/lib/pages/create_community_page/create_community_page.dart
@@ -24,15 +24,6 @@ class CreateCommunityPageState extends State<CreateCommunityPage> {
       ),
       body: Column(
         children: [
-          const SizedBox(
-            height: 30,
-          ),
-          Center(
-            child: Text(
-              "Hello ${user?.name}",
-              style: const TextStyle(fontSize: 30),
-            ),
-          ),
           const SizedBox(height: 20),
           CreateCommunityWidget(token: user?.idToken ?? "INVALID TOKEN"),
         ],

--- a/lib/pages/search_page/seach_results_widget.dart
+++ b/lib/pages/search_page/seach_results_widget.dart
@@ -20,6 +20,24 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
   TextEditingController userInput = TextEditingController();
   Community _community = Community(communityName: '', creationDate: 1, creator: '', members: []);
   User _user = User(username: '', name: '', communities: []);
+  
+    showLoading(BuildContext context){
+    AlertDialog loadStatus = AlertDialog( 
+      content: new Row( 
+        children: [
+          CircularProgressIndicator(),
+        ]
+      )
+    );
+      showDialog(
+        barrierDismissible: false,
+        context: context,
+        builder: (BuildContext context){
+          return loadStatus;
+        },
+      );
+
+  }
 
   getSearchResults() {
     _community = Community(communityName: '', creationDate: 1, creator: '', members: []);
@@ -27,9 +45,10 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
     final Future<Map<String, dynamic>> apiResponse = API.getSearchResults(userInput.text, widget.token);
     apiResponse.then((response) {
       if (response['status'] == true) {
+        Navigator.pop(context);
         // print("ABE SAYS: " + response['searchResults'].toString());
         if (!response['searchResults']['communities'].isEmpty) {
-          print("COMMUNIT IS: " + response['searchResults']['communities'][0].toString());
+          print("COMMUNITY IS: " + response['searchResults']['communities'][0].toString());
 
           Community community = Community.fromJson(response['searchResults']['communities'][0]);
           print("objectobjectobject");
@@ -43,13 +62,31 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
             _user = user;
           });
         }
-      } else {
+         else if (response['searchResults']['communities'].isEmpty && response['searchResults']['users'].isEmpty) {
+        //Navigator.pop(context);
         showDialog(
             context: context,
             builder: (context) {
               return AlertDialog(
                 title: const Text("Error!"),
                 content: Text("No results found. Try creating the community ${userInput.text}."),
+                actions: [
+                  TextButton(
+                      onPressed: () {
+                        Navigator.pop(context);
+                      },
+                      child: const Text("Ok"))
+                ],
+              );
+            });
+         }
+      } else {
+        showDialog(
+            context: context,
+            builder: (context) {
+              return AlertDialog(
+                title: const Text("Error!"),
+                content: Text("No results found. Try searching again."),
                 actions: [
                   TextButton(
                       onPressed: () {
@@ -86,6 +123,7 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
             suffixIcon: IconButton(
               icon: const Icon(Icons.search),
               onPressed: () async {
+                showLoading(context);
                 getSearchResults();
               },
               style: IconButton.styleFrom(
@@ -101,51 +139,25 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
           style: TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold),
         ),
       if (_community.communityName != '')
-        SizedBox(
-          height: MediaQuery.of(context).size.height * 0.3,
+       SizedBox(
           width: MediaQuery.of(context).size.width,
           child: Card(
-            margin: const EdgeInsets.only(top: 20.0),
-            child: Column(
-              children: <Widget>[
-                const SizedBox(height: 10),
-                Text(
-                  "c/${_community.communityName}",
-                  style: const TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  "Created on ${getFormattedDate(_community.creationDate)}",
-                  style: const TextStyle(fontSize: 16),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  // ignore: unrelated_type_equality_checks
-                  "${_community.members.length} members",
-                  style: const TextStyle(fontSize: 16),
-                  textAlign: TextAlign.center,
-                ),
-                TextButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => CommunityPage(
+            child: TextButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => CommunityPage(
                           communityName: _community.communityName,
                           token: widget.token,
                         ),
-                      ),
-                    );
-                  },
-                  style: TextButton.styleFrom(
-                    primary: Colors.white,
-                    backgroundColor: Colors.blue,
                   ),
-                  child: const Text("visit community"),
-                ),
-                const SizedBox(height: 10),
-              ],
+                );
+              },
+              child: Text(
+                "c/${_community.communityName}",
+                style: const TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold),
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Remove "hello <user>" from creation page for UI

Make search results look the same for /u and /c

Remove redundant text (create community)
<img width="359" alt="Screen Shot 2022-10-30 at 1 57 37 AM" src="https://user-images.githubusercontent.com/98794408/198864965-6363abbd-20d1-4a0e-81d3-c81de4ae24cd.png">
<img width="355" alt="Screen Shot 2022-10-30 at 1 59 25 AM" src="https://user-images.githubusercontent.com/98794408/198864974-c854e084-098f-4bf0-9ccd-320b3b6c1596.png">
<img width="343" alt="Screen Shot 2022-10-30 at 1 59 49 AM" src="https://user-images.githubusercontent.com/98794408/198864975-335dead6-e29e-4f43-b9a4-88ec1493dbb9.png">
<img width="338" alt="Screen Shot 2022-10-30 at 2 00 05 AM" src="https://user-images.githubusercontent.com/98794408/198864976-a06d95b0-e9d5-42fc-a4c4-17a68bd2f42e.png">
<img width="336" alt="Screen Shot 2022-10-30 at 2 00 16 AM" src="https://user-images.githubusercontent.com/98794408/198864977-7e1e0d65-3a05-4902-a11f-8094eb62e0dc.png">
