### PR TITLE
Add UI changes for search/create

### DIFF
--- a/lib/pages/create_community_page/create_community.dart
+++ b/lib/pages/create_community_page/create_community.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:linear/util/apis.dart';
+import 'package:linear/pages/community_page/community_page.dart';
+import 'package:linear/pages/search_page/seach_results_widget.dart';
 
 class CreateCommunityWidget extends StatefulWidget {
   CreateCommunityWidget({super.key, required this.token});
@@ -17,6 +19,7 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
 
     successfulMessage.then((response) {
       if (response['status'] == true) {
+        joinAndLeave(userInput.text, widget.token);
         showDialog(
             context: context,
             builder: (context) {
@@ -26,9 +29,40 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
                 actions: [
                   TextButton(
                       onPressed: () {
-                        Navigator.pop(context);
-                        //add routintg to community page
-                      },
+                       Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => CommunityPage(
+                          communityName: userInput.text,
+                          token: widget.token,
+                        ),
+                      ),
+                    );
+                  },
+                      child: const Text("Ok"))
+                ],
+              );
+            });
+      } else if (response['message'] == 'The community already exists!'){
+        showDialog(
+            context: context,
+            builder: (context) {
+              return AlertDialog(
+                title: const Text("Error!"),
+                content: const Text("Community already exists!"),
+                actions: [
+                  TextButton(
+                      onPressed: () {
+                       Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => CommunityPage(
+                          communityName: userInput.text,
+                          token: widget.token,
+                        ),
+                      ),
+                    );
+                  },
                       child: const Text("Ok"))
                 ],
               );
@@ -56,12 +90,6 @@ class _CreateCommunityWidgetState extends State<CreateCommunityWidget> {
   @override
   Widget build(BuildContext context) {
     return Column(children: [
-      const Center(
-        child: Text(
-          "Create a Community:",
-          style: TextStyle(fontSize: 24),
-        ),
-      ),
       Container(
         margin: const EdgeInsets.all(10),
         child: TextFormField(

--- a/lib/pages/create_community_page/create_community_page.dart
+++ b/lib/pages/create_community_page/create_community_page.dart
@@ -24,15 +24,6 @@ class CreateCommunityPageState extends State<CreateCommunityPage> {
       ),
       body: Column(
         children: [
-          const SizedBox(
-            height: 30,
-          ),
-          Center(
-            child: Text(
-              "Hello ${user?.name}",
-              style: const TextStyle(fontSize: 30),
-            ),
-          ),
           const SizedBox(height: 20),
           CreateCommunityWidget(token: user?.idToken ?? "INVALID TOKEN"),
         ],

--- a/lib/pages/search_page/seach_results_widget.dart
+++ b/lib/pages/search_page/seach_results_widget.dart
@@ -20,6 +20,24 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
   TextEditingController userInput = TextEditingController();
   Community _community = Community(communityName: '', creationDate: 1, creator: '', members: []);
   User _user = User(username: '', name: '', communities: []);
+  
+    showLoading(BuildContext context){
+    AlertDialog loadStatus = AlertDialog( 
+      content: new Row( 
+        children: [
+          CircularProgressIndicator(),
+        ]
+      )
+    );
+      showDialog(
+        barrierDismissible: false,
+        context: context,
+        builder: (BuildContext context){
+          return loadStatus;
+        },
+      );
+
+  }
 
   getSearchResults() {
     _community = Community(communityName: '', creationDate: 1, creator: '', members: []);
@@ -27,9 +45,10 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
     final Future<Map<String, dynamic>> apiResponse = API.getSearchResults(userInput.text, widget.token);
     apiResponse.then((response) {
       if (response['status'] == true) {
+        Navigator.pop(context);
         // print("ABE SAYS: " + response['searchResults'].toString());
         if (!response['searchResults']['communities'].isEmpty) {
-          print("COMMUNIT IS: " + response['searchResults']['communities'][0].toString());
+          print("COMMUNITY IS: " + response['searchResults']['communities'][0].toString());
 
           Community community = Community.fromJson(response['searchResults']['communities'][0]);
           print("objectobjectobject");
@@ -43,13 +62,17 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
             _user = user;
           });
         }
+        /*else{ 
+           Navigator.pop(context);
+        }*/
       } else {
+        Navigator.pop(context);
         showDialog(
             context: context,
             builder: (context) {
               return AlertDialog(
                 title: const Text("Error!"),
-                content: Text("No results found. Try creating the community ${userInput.text}."),
+                content: Text("No results found. Try searching again."),
                 actions: [
                   TextButton(
                       onPressed: () {
@@ -65,7 +88,13 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Column(children: [
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+         const Align(
+                  alignment: Alignment.centerLeft,
+              ),
       Container(
         margin: const EdgeInsets.all(10),
         child: TextFormField(
@@ -86,6 +115,7 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
             suffixIcon: IconButton(
               icon: const Icon(Icons.search),
               onPressed: () async {
+                showLoading(context);
                 getSearchResults();
               },
               style: IconButton.styleFrom(
@@ -95,71 +125,52 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
           ),
         ),
       ),
-      if (_community.communityName != '')
-        const Text(
-          "communities:",
-          style: TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold),
+      if (_community.communityName == '' && _user.username == '')
+       SizedBox(
+          width: MediaQuery.of(context).size.width,
+          child: const Card(
+            margin: EdgeInsets.symmetric(horizontal: 10),
+            child: Text("No results found",
+            style: TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold),)
+          ),
         ),
       if (_community.communityName != '')
-        SizedBox(
-          height: MediaQuery.of(context).size.height * 0.3,
-          width: MediaQuery.of(context).size.width,
+      Container( 
+        width: MediaQuery.of(context).size.width,
+        padding: const EdgeInsets.all(3.0),
           child: Card(
-            margin: const EdgeInsets.only(top: 20.0),
-            child: Column(
-              children: <Widget>[
-                const SizedBox(height: 10),
-                Text(
-                  "c/${_community.communityName}",
-                  style: const TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  "Created on ${getFormattedDate(_community.creationDate)}",
-                  style: const TextStyle(fontSize: 16),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 10),
-                Text(
-                  // ignore: unrelated_type_equality_checks
-                  "${_community.members.length} members",
-                  style: const TextStyle(fontSize: 16),
-                  textAlign: TextAlign.center,
-                ),
-                TextButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => CommunityPage(
+            margin: EdgeInsets.symmetric(horizontal: 10),
+            child: Container(
+              alignment: Alignment.centerLeft, 
+              child: TextButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => CommunityPage(
                           communityName: _community.communityName,
                           token: widget.token,
                         ),
-                      ),
-                    );
-                  },
-                  style: TextButton.styleFrom(
-                    primary: Colors.white,
-                    backgroundColor: Colors.blue,
                   ),
-                  child: const Text("visit community"),
-                ),
-                const SizedBox(height: 10),
-              ],
+                );
+              },
+              child: Text(
+                "c/${_community.communityName}", textAlign: TextAlign.left,
+                style: const TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold,),
+              ),
             ),
           ),
         ),
-      const SizedBox(height: 20),
+      ),
       if (_user.username != '')
-        const Text(
-          "Users:",
-          style: TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold),
-        ),
-      if (_user.username != '')
-        SizedBox(
+        Container(
+          padding: const EdgeInsets.all(3.0),
           width: MediaQuery.of(context).size.width,
-          child: Card(
-            child: TextButton(
+         child: Card(
+            margin: EdgeInsets.symmetric(horizontal: 10),
+            child: Container(
+              alignment: Alignment.centerLeft, 
+              child: TextButton(
               onPressed: () {
                 Navigator.push(
                   context,
@@ -171,10 +182,11 @@ class _SearchResultWidgetState extends State<SearchResultWidget> {
                 );
               },
               child: Text(
-                "u/${_user.username}",
+                "u/${_user.username}", textAlign: TextAlign.left,
                 style: const TextStyle(fontFamily: 'MonteSerrat', fontSize: 24, fontWeight: FontWeight.bold),
               ),
             ),
+          ),
           ),
         ),
       const SizedBox(height: 10),

--- a/lib/util/apis.dart
+++ b/lib/util/apis.dart
@@ -20,7 +20,9 @@ Future<Map<String, dynamic>> postCommunity(String communityName, String token) a
       if (response.statusCode == 200) {
         print("Success!");
         return {'status': true, 'message': 'Community Succesfully Created.'};
-      } else {
+      } else if('${response.body}' == '{"message":"The community already exists!"}'){
+        return {'status': false, 'message': 'The community already exists!'};
+      }else{
         return {'status': false, 'message': 'An error occurred while creating the community, please try again.'};
       }
     },


### PR DESCRIPTION
Remove "hello <user>" from creation page for UI
Add load status, make results consistent
Remove redundant text (create community)(community and users headers)
<img width="338" alt="11:1 already exists" src="https://user-images.githubusercontent.com/98794408/199336791-8d2deeab-ecbc-4e3b-aac4-a8e8a1c5912f.png">
<img width="342" alt="11:1 no results" src="https://user-images.githubusercontent.com/98794408/199336793-0b6beb9a-7af4-4f5e-b258-d260ff10e31e.png">
<img width="352" alt="11:1 search" src="https://user-images.githubusercontent.com/98794408/199336796-60cab34f-0219-46fd-9c5c-33e9db540d1f.png">

Add "no results"  on page, if community exists already go there
