### PR TITLE
Fixed delete post

### DIFF
--- a/lib/auth_pages/sign_in.dart
+++ b/lib/auth_pages/sign_in.dart
@@ -141,7 +141,7 @@ class _LoginPageState extends State<LoginPage> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      const Text("Dont't have an account?"),
+                      const Text("Don't have an account?"),
                       TextButton(
                         onPressed: () {
                           Navigator.push(

--- a/lib/pages/community_page/community_page.dart
+++ b/lib/pages/community_page/community_page.dart
@@ -202,6 +202,11 @@ class CommunityPageState extends State<CommunityPage> {
                           body: _posts[index]['body'],
                           likes: _posts[index]['likes'],
                         ),
+                        onDelete: () {
+                        setState(() {
+                           _posts.removeAt(index);
+                              });
+                        },
                       );
                     },
                   ),

--- a/lib/pages/home_page/home_page_content.dart
+++ b/lib/pages/home_page/home_page_content.dart
@@ -101,6 +101,11 @@ class _HomePageContentState extends State<HomePageContent> {
                                 body: _post[index]['body'],
                                 likes: _post[index]['likes'],
                               ),
+                              onDelete: () {  
+                              setState(() {
+                                _post.removeAt(index);
+                              });
+                            },
                             );
                           },
                         ),

--- a/lib/pages/post_page/post_page.dart
+++ b/lib/pages/post_page/post_page.dart
@@ -36,6 +36,10 @@ class PostPageState extends State<PostPage> {
     doGetPost();
   }
 
+  delete() {
+    Navigator.pop(context);
+  }
+
   doGetPost() {
     final Future<Map<String, dynamic>> responseMessage = getPostWithComments(widget.postId, widget.token);
     responseMessage.then((response) {
@@ -98,7 +102,10 @@ class PostPageState extends State<PostPage> {
                     });
                   },
                   token: widget.token,
-                  post: _post,
+                  post: _post, 
+                  onDelete: () {
+                    delete();
+                    },
                 ),
               ),
               const SizedBox(height: 10),

--- a/lib/pages/profile_page/get_profile.dart
+++ b/lib/pages/profile_page/get_profile.dart
@@ -395,6 +395,11 @@ class _GetProfileWidgetState extends State<GetProfileWidget> {
                                 body: _post[index]['body'],
                                 likes: _post[index]['likes'],
                               ),
+                              onDelete: () { 
+                              setState(() {
+                                _post.removeAt(index);
+                              });
+                             },
                             );
                           },
                         ),

--- a/lib/util/apis.dart
+++ b/lib/util/apis.dart
@@ -97,6 +97,33 @@ Future<Map<String, dynamic>> createPost(String postTitle, String postBody, Strin
   );
 }
 
+Future<Map<String, dynamic>> deletePost(String postId, String token) async {
+  const url ='https://qgzp9bo610.execute-api.us-east-1.amazonaws.com/prod/post';
+  return await http.delete(
+    Uri.parse(url),
+    body: jsonEncode({
+      "postId": postId,
+    }),
+    headers: {
+      "Authorization": token,
+      "Content-Type": "application/json",
+    },
+  ).then(
+    (response) {
+      if (response.statusCode == 200) {
+        print("Success!");
+        return {'status': true, 'message': 'Post Succesfully Deleted.'};
+      } else {
+        return {
+          'status': false,
+          'message':
+              'An error occurred while deleting the post, please try again.'
+        };
+      }
+    },
+  );
+}
+
 Future<Map<String, dynamic>> likePost(String postId, String token) async {
   var url = 'https://qgzp9bo610.execute-api.us-east-1.amazonaws.com/prod/like?postId=$postId';
   try {


### PR DESCRIPTION
Pages are reactive when a user wishes to delete a post (watch video)
User cannot delete post that he or she does not submit (refer to image 2; the same would apply to posts made by Tanvir and Annabelle if I were to see their posts)
Also, typo for sign in page has been fixed from "dont't" to "don't" (check image 3)

https://user-images.githubusercontent.com/91173297/201460469-831bfa5e-bd39-41c7-b891-9d7b288ce62b.mov

<img width="363" alt="user cannot delete all posts" src="https://user-images.githubusercontent.com/91173297/201460411-bd999aa2-683a-45bc-aeae-e4e1fe35a604.png">

<img width="345" alt="sign in typo" src="https://user-images.githubusercontent.com/91173297/201460427-be8557bc-dadb-4cdb-856a-116b0a999b67.png">