### PR TITLE
Fix pixel overflow on widgets + Edit character count for posts and comments

### DIFF
--- a/lib/inroduction_page/intro_banner.dart
+++ b/lib/inroduction_page/intro_banner.dart
@@ -33,17 +33,20 @@ class _LinearIntroBannerState extends State<LinearIntroBanner> {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: [
-            TextButton(
-              onPressed: (){
-                Navigator.push(context, MaterialPageRoute(builder: (context) => const LinearIntro()),);
-              },
-              child: const Text(
-                "Click here to get to know the linear App!",
-                style: TextStyle(
-                  fontSize: 14, 
-                  fontWeight: FontWeight.w700,
-                  color: Colors.black,
-                )
+            Expanded(
+              child: TextButton(
+                onPressed: (){
+                  Navigator.push(context, MaterialPageRoute(builder: (context) => const LinearIntro()),);
+                },
+                child: const Text(
+                  "Click here to get to know the linear App!",
+                  style: TextStyle(
+                    fontSize: 13, 
+                    fontWeight: FontWeight.w700,
+                    color: Colors.black,
+                  ),
+                  maxLines: 1
+                ),
               ),
             ),
             IconButton(

--- a/lib/pages/common_widgets/create_community_page.dart
+++ b/lib/pages/common_widgets/create_community_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:linear/pages/common_widgets/navbar.dart';
 import 'package:linear/pages/community_page/community_page.dart';
 import 'package:linear/util/apis.dart';
@@ -102,7 +103,8 @@ class CreateCommunityPageState extends State<CreateCommunityPage> {
         title: const Text("Create Community"),
         elevation: 0.1,
       ),
-      body: Column(children: [
+      body: Column(
+      children: [
       Container(
         margin: const EdgeInsets.all(10),
         child: TextFormField(
@@ -110,6 +112,9 @@ class CreateCommunityPageState extends State<CreateCommunityPage> {
           style: const TextStyle(
             fontSize: 20,
           ),
+          inputFormatters: [
+          LengthLimitingTextInputFormatter(50),
+          ],
           onChanged: (value) {
             setState(() {});
           },

--- a/lib/pages/common_widgets/post_widget.dart
+++ b/lib/pages/common_widgets/post_widget.dart
@@ -322,7 +322,7 @@ class _PostWidget extends State<PostWidget> {
                                 style: const TextStyle(
                                     fontSize: 20,
                                     fontWeight: FontWeight.bold),
-                                textAlign: TextAlign.center,
+                                textAlign: TextAlign.left,
                               ),
                               const SizedBox(height: 5),
                               if (widget.post.body.length > 300) ...[

--- a/lib/pages/community_page/create_post_widget.dart
+++ b/lib/pages/community_page/create_post_widget.dart
@@ -165,7 +165,7 @@ class _CreatePostWidgetState extends State<CreatePostWidget> {
                     style: const TextStyle(
                       fontSize: 20,
                     ),
-                    maxLength: 300,
+                    maxLength: 1000,
                     onChanged: (value) {
                       setState(() {});
                     },

--- a/lib/pages/community_page/create_post_widget.dart
+++ b/lib/pages/community_page/create_post_widget.dart
@@ -160,24 +160,21 @@ class _CreatePostWidgetState extends State<CreatePostWidget> {
               Container(
                 margin: const EdgeInsets.all(10),
                 child: Expanded(
-                  child: SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: TextFormField(
-                      controller: postBodyInput,
-                      style: const TextStyle(
-                        fontSize: 20,
+                  child: TextFormField(
+                    controller: postBodyInput,
+                    style: const TextStyle(
+                      fontSize: 20,
+                    ),
+                    maxLength: 300,
+                    onChanged: (value) {
+                      setState(() {});
+                    },
+                    keyboardType: TextInputType.multiline,
+                    decoration: InputDecoration(
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(5.0),
                       ),
-                      maxLength: 300,
-                      onChanged: (value) {
-                        setState(() {});
-                      },
-                      keyboardType: TextInputType.multiline,
-                      decoration: InputDecoration(
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(5.0),
-                        ),
-                        hintText: "body...",
-                      ),
+                      hintText: "body...",
                     ),
                   ),
                 ),

--- a/lib/pages/community_page/create_post_widget.dart
+++ b/lib/pages/community_page/create_post_widget.dart
@@ -120,6 +120,8 @@ class _CreatePostWidgetState extends State<CreatePostWidget> {
     }
     return Container(
       margin: const EdgeInsets.all(20),
+      width: MediaQuery.of(context).size.width * 0.9,
+      height: MediaQuery.of(context).size.height * 0.5,
       child: Card(
         margin: const EdgeInsets.only(top: 20.0, bottom: 20.0),
         child: Padding(
@@ -157,21 +159,26 @@ class _CreatePostWidgetState extends State<CreatePostWidget> {
               ),
               Container(
                 margin: const EdgeInsets.all(10),
-                child: TextFormField(
-                  controller: postBodyInput,
-                  style: const TextStyle(
-                    fontSize: 20,
-                  ),
-                  onChanged: (value) {
-                    setState(() {});
-                  },
-                  keyboardType: TextInputType.multiline,
-                  maxLines: null,
-                  decoration: InputDecoration(
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(5.0),
+                child: Expanded(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: TextFormField(
+                      controller: postBodyInput,
+                      style: const TextStyle(
+                        fontSize: 20,
+                      ),
+                      maxLength: 300,
+                      onChanged: (value) {
+                        setState(() {});
+                      },
+                      keyboardType: TextInputType.multiline,
+                      decoration: InputDecoration(
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(5.0),
+                        ),
+                        hintText: "body...",
+                      ),
                     ),
-                    hintText: "body...",
                   ),
                 ),
               ),

--- a/lib/pages/post_page/create_comment_widget.dart
+++ b/lib/pages/post_page/create_comment_widget.dart
@@ -92,22 +92,25 @@ class _CreateCommentWidgetState extends State<CreateCommentWidget> {
               ),
               Container(
                 margin: const EdgeInsets.all(10),
-                child: TextFormField(
-                  controller: commentBodyInput,
-                  inputFormatters: [
-                    LengthLimitingTextInputFormatter(256),
-                  ],
-                  style: const TextStyle(
-                    fontSize: 20,
-                  ),
-                  onChanged: (value) {
-                    setState(() {});
-                  },
-                  decoration: InputDecoration(
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(5.0),
+                child: Expanded(
+                  child: TextFormField(
+                    controller: commentBodyInput,
+                    maxLength: 256,
+                    inputFormatters: [
+                      LengthLimitingTextInputFormatter(256),
+                    ],
+                    style: const TextStyle(
+                      fontSize: 20,
                     ),
-                    hintText: "comment body",
+                    onChanged: (value) {
+                      setState(() {});
+                    },
+                    decoration: InputDecoration(
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(5.0),
+                      ),
+                      hintText: "comment body",
+                    ),
                   ),
                 ),
               ),

--- a/lib/pages/post_page/post_page.dart
+++ b/lib/pages/post_page/post_page.dart
@@ -321,10 +321,12 @@ class PostPageState extends State<PostPage> {
                             ),
                             Row(
                               children: [
-                                Text(
-                                  _comments[index]['body'],
-                                  style: const TextStyle(fontSize: 18),
-                                  textAlign: TextAlign.left,
+                                Expanded(
+                                  child: Text(
+                                    _comments[index]['body'],
+                                    style: const TextStyle(fontSize: 18),
+                                    textAlign: TextAlign.left,
+                                  ),
                                 ),
                               ],
                             ),


### PR DESCRIPTION
Fixed intro banner (no overflow):
<img width="329" alt="fixed intro banner" src="https://user-images.githubusercontent.com/91173297/205197720-c25966e3-b33f-44dd-9610-4d369e987ebc.png">

Character count for comment:
<img width="297" alt="character count for comment" src="https://user-images.githubusercontent.com/91173297/205197800-80b78f2b-ffd5-4197-a90f-b1cf981f10f6.png">

Fixed comment body (no overflow):
<img width="315" alt="Fixed comment body (no overflow)" src="https://user-images.githubusercontent.com/91173297/205197901-108fd1d6-b2a7-4eaf-9d4c-96aaa81892aa.png">

Character count for post (this has been updated to 1000 after reviewing lambda):
<img width="280" alt="post" src="https://user-images.githubusercontent.com/91173297/205197926-6491336a-ae2d-450b-8363-1258f74362f1.png">

Fixed post body (no overflow error):
<img width="315" alt="post body" src="https://user-images.githubusercontent.com/91173297/205197952-b7ed5362-2c9b-4908-b622-46994d25f368.png">
